### PR TITLE
Fix: added url attribute to client in remote_agent_connection.py 

### DIFF
--- a/purchasing_concierge/remote_agent_connection.py
+++ b/purchasing_concierge/remote_agent_connection.py
@@ -104,6 +104,9 @@ class RemoteAgentConnections:
         self._httpx_client = httpx.AsyncClient(timeout=30)
         self.agent_client = A2AClient(self._httpx_client, agent_card, url=agent_url)
 
+        # Set the URL attribute for the custom _send_request method avoiding url attribute error in line 52
+        self.agent_client.url = agent_url
+
         # Replace the original method with our custom implementation
         # NOTE: This is a temporary workaround for issue in httpx event closed
         self.agent_client._send_request = _send_request.__get__(self.agent_client)


### PR DESCRIPTION
Set url attribute to client in ```remote_agent_connection.py``` ```RemoteAgentConnections class``` ```__init__``` method to avoid error in ```_send_request``` expecting self.url raising an ```AttributeError: 'A2AClient' object has no attribute 'url' ```

```
def _send_request(...):
    ...
    try:
        response = requests.post(
            self.url, json=rpc_request_payload, **(http_kwargs or {})
        )
    ....
```